### PR TITLE
Added exclusion routes to staticwebapp.config.json

### DIFF
--- a/Gallery.Web/public/staticwebapp.config.json
+++ b/Gallery.Web/public/staticwebapp.config.json
@@ -2,16 +2,7 @@
     "navigationFallback": {
         "rewrite": "/index.html",
         "exclude": [
-            "*.{css, svg, js, ts, png, jpeg, jpg, ico}",
-            "auth/check",
-            "auth/login",
-            "auth/logout",
-            "imageCollections",
-            "imageCollections/{id}",
-            "images",
-            "images/{id}",
-            "tags",
-            "tags/{id}"
+            "*.{css, svg, js, ts, png, jpeg, jpg, ico}"
         ]
     }
 }

--- a/Gallery.Web/public/staticwebapp.config.json
+++ b/Gallery.Web/public/staticwebapp.config.json
@@ -2,7 +2,16 @@
     "navigationFallback": {
         "rewrite": "/index.html",
         "exclude": [
-            "*.{css, svg, js, ts, png, jpeg, jpg, ico}"
+            "*.{css, svg, js, ts, png, jpeg, jpg, ico}",
+            "auth/check",
+            "auth/login",
+            "auth/logout",
+            "imageCollections",
+            "imageCollections/{id}",
+            "images",
+            "images/{id}",
+            "tags",
+            "tags/{id}"
         ]
     }
 }

--- a/Gallery.Web/src/main.ts
+++ b/Gallery.Web/src/main.ts
@@ -34,6 +34,7 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to, from, next) => {
+    console.log(import.meta.env.VITE_API_URL);
     console.log("beforeEach", to.path, store.state.isAuthenticated)
     if (to.path === '/admin') {
         !store.state.isAuthenticated ? next({ path: '/login', query: { redirect: '/admin' } })

--- a/Gallery.Web/src/main.ts
+++ b/Gallery.Web/src/main.ts
@@ -34,7 +34,8 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to, from, next) => {
-    console.log(import.meta.env.VITE_API_URL);
+    const url = import.meta.env.VITE_API_URL;
+    console.log(url);
     console.log("beforeEach", to.path, store.state.isAuthenticated)
     if (to.path === '/admin') {
         !store.state.isAuthenticated ? next({ path: '/login', query: { redirect: '/admin' } })


### PR DESCRIPTION
Exclude specific routes from navigation fallback in staticwebapp.config.json. This ensures that certain routes, such as authentication and API endpoints, are not rewritten to index.html. The excluded routes include: auth/check, auth/login, auth/logout, imageCollections, imageCollections/{id}, images, images/{id}, tags, and tags/{id}.